### PR TITLE
Tweaks to "chimpanzee_tempt_items"

### DIFF
--- a/src/main/resources/data/neapolitan/tags/items/chimpanzee_tempt_items.json
+++ b/src/main/resources/data/neapolitan/tags/items/chimpanzee_tempt_items.json
@@ -2,8 +2,18 @@
   "replace": false,
   "values": [
     "#neapolitan:chimpanzee_food",
+    "neapolitan:banana_bundle",
     "neapolitan:banana_bread",
+    "neapolitan:banana_cake",
+    "neapolitan:banana_ice_cream",
+    "neapolitan:banana_ice_cream_block",
+    "neapolitan:banana_milkshake",
+    "neapolitan:bananaroow",
     "neapolitan:dried_banana",
-    "neapolitan:banana"
+    "neapolitan:banana_crate",
+    "#forge:fruits/banana"
+  ],
+  "optional": [
+    "abnormals_delight:banana_cake_slice"
   ]
 }


### PR DESCRIPTION
- Now includes all of Neapolitan's banana-related items, except strawberry banana smoothie, banana fronds and banana stalks (for obvious reasons);
- Any items on "forge:fruits/banana" tag are now supported.