### PR TITLE
Register Neapolitan config values with config condition

### DIFF
--- a/src/main/java/com/minecraftabnormals/neapolitan/core/Neapolitan.java
+++ b/src/main/java/com/minecraftabnormals/neapolitan/core/Neapolitan.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.neapolitan.core;
 
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.minecraftabnormals.neapolitan.core.other.NeapolitanCompat;
 import com.minecraftabnormals.neapolitan.core.registry.*;
@@ -36,6 +37,7 @@ public class Neapolitan {
 		});
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, NeapolitanConfig.COMMON_SPEC);
+		DataUtil.registerConfigCondition(Neapolitan.MOD_ID, NeapolitanConfig.COMMON);
 	}
 
 	private void commonSetup(FMLCommonSetupEvent event) {

--- a/src/main/java/com/minecraftabnormals/neapolitan/core/NeapolitanConfig.java
+++ b/src/main/java/com/minecraftabnormals/neapolitan/core/NeapolitanConfig.java
@@ -1,26 +1,50 @@
 package com.minecraftabnormals.neapolitan.core;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class NeapolitanConfig {
 	public static class Common {
+
+		@ConfigKey("milk_cauldron_enabled")
 		public final ConfigValue<Boolean> milkCauldron;
+
+		@ConfigKey("milking_with_glass_bottles_enabled")
 		public final ConfigValue<Boolean> milkingWithGlassBottles;
 
+
+		@ConfigKey("strawberry_bush_generation_chance")
 		public final ConfigValue<Integer> strawberryBushGenerationChance;
+
+		@ConfigKey("vanilla_vine_generation_chance")
 		public final ConfigValue<Integer> vanillaVineGenerationChance;
+
+		@ConfigKey("adzuki_sprouts_generation_chance")
 		public final ConfigValue<Integer> adzukiSproutsGenerationChance;
+
+		@ConfigKey("mint_pond_generation_chance")
 		public final ConfigValue<Integer> mintPondGenerationChance;
 
+
+		@ConfigKey("banana_plants_generate_in_beaches")
 		public final ConfigValue<Boolean> bananaPlantBeachGeneration;
+
+		@ConfigKey("banana_plants_generate_in_jungles")
 		public final ConfigValue<Boolean> bananaPlantJungleGeneration;
 
+		@ConfigKey("plantain_spiders_spawn_in_jungle")
 		public final ConfigValue<Boolean> plantainSpiderSpawning;
+
+		@ConfigKey("plantain_spiders_spawn_from_bundles")
 		public final ConfigValue<Boolean> plantainSpidersFromBundles;
+
+		@ConfigKey("plantain_spiders_give_slipping")
 		public final ConfigValue<Boolean> plantainSpidersGiveSlipping;
 
+
+		@ConfigKey("chimpanzees_spawn_in_jungle")
 		public final ConfigValue<Boolean> chimpanzeeSpawning;
 
 		Common(ForgeConfigSpec.Builder builder) {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.